### PR TITLE
Show ccache config

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -128,9 +128,46 @@ function ccachestatsverbose() {
 }
 
 # Compile
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache configuration"
+  ccache --show-config
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache log stats"
+  ccache --show-log-stats
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache log stats (verbose)"
+  ccache --show-log-stats --verbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache log stats (verbose verbose)"
+  ccache --show-log-stats --verbose --verbose
+  echo "::endgroup::"
+fi
+
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats"
   ccachestatsverbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache stats (verbose)"
+  ccache --show-config --verbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache stats (verbose verbose)"
+  ccache --show-config --verbose --verbose
   echo "::endgroup::"
 fi
 
@@ -152,6 +189,8 @@ echo "::endgroup::"
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats again"
   ccachestatsverbose
+  # Zero cache statistics at the end - useful?
+  # ccache --zero-stats
   echo "::endgroup::"
 fi
 

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -178,7 +178,6 @@ fi
 
 if [[ $MAKE_PACKAGE ]]; then
   echo "::group::Create package"
-  
   if [[ $RUNNER_OS == macOS ]]; then
     # Workaround https://github.com/actions/runner-images/issues/7522
     echo "killing XProtectBehaviorService"; sudo pkill -9 XProtect >/dev/null || true;
@@ -186,7 +185,6 @@ if [[ $MAKE_PACKAGE ]]; then
   fi
   cmake --build . --target package --config "$BUILDTYPE"
   echo "::endgroup::"
-
   if [[ $PACKAGE_SUFFIX ]]; then
     echo "::group::Update package name"
     cd ..

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -136,18 +136,6 @@ if [[ $USE_CCACHE ]]; then
 fi
 
 if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats (verbose)"
-  ccache --show-config --verbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats (verbose verbose)"
-  ccache --show-config --verbose --verbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache log stats"
   # ccache --show-log-stats
   echo "::endgroup::"
@@ -168,6 +156,18 @@ fi
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats"
   ccachestatsverbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache stats (verbose)"
+  ccache --show-stats --verbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache stats (verbose verbose)"
+  ccache --show-stats --verbose --verbose
   echo "::endgroup::"
 fi
 

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -136,30 +136,6 @@ if [[ $USE_CCACHE ]]; then
 fi
 
 if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache log stats"
-  ccache --show-log-stats
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache log stats (verbose)"
-  ccache --show-log-stats --verbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache log stats (verbose verbose)"
-  ccache --show-log-stats --verbose --verbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats"
-  ccachestatsverbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats (verbose)"
   ccache --show-config --verbose
   echo "::endgroup::"
@@ -168,6 +144,30 @@ fi
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats (verbose verbose)"
   ccache --show-config --verbose --verbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache log stats"
+  # ccache --show-log-stats
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache log stats (verbose)"
+  # ccache --show-log-stats --verbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache log stats (verbose verbose)"
+  # ccache --show-log-stats --verbose --verbose
+  echo "::endgroup::"
+fi
+
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache stats"
+  ccachestatsverbose
   echo "::endgroup::"
 fi
 

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -159,7 +159,7 @@ echo "::endgroup::"
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats again"
   ccachestatsverbose
-  # Zero cache statistics at the end - useful?
+  # Zero cache statistics at the end - useful? Clear at the beginning before the build instead?
   # ccache --zero-stats
   echo "::endgroup::"
 fi

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -136,38 +136,19 @@ if [[ $USE_CCACHE ]]; then
 fi
 
 if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache log stats"
-  # ccache --show-log-stats
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache log stats (verbose)"
-  # ccache --show-log-stats --verbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache log stats (verbose verbose)"
-  # ccache --show-log-stats --verbose --verbose
+  echo "::group::Print ccache.conf"
+  if [ -f "${CCACHE_DIR}/ccache.conf" ]; then
+    echo "Contents of ccache.conf:"
+    cat "${CCACHE_DIR}/ccache.conf"
+    else
+      echo "No ccache.conf file found at ${CCACHE_DIR}/ccache.conf"
+  fi
   echo "::endgroup::"
 fi
 
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats"
   ccachestatsverbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats (verbose)"
-  ccache --show-stats --verbose
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache stats (verbose verbose)"
-  ccache --show-stats --verbose --verbose
   echo "::endgroup::"
 fi
 

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -130,19 +130,8 @@ function ccachestatsverbose() {
 # Compile
 
 if [[ $USE_CCACHE ]]; then
-  echo "::group::Show ccache configuration"
+  echo "::group::Show ccache config"
   ccache --show-config
-  echo "::endgroup::"
-fi
-
-if [[ $USE_CCACHE ]]; then
-  echo "::group::Print ccache.conf"
-  if [ -f "${CCACHE_DIR}/ccache.conf" ]; then
-    echo "Contents of ccache.conf:"
-    cat "${CCACHE_DIR}/ccache.conf"
-    else
-      echo "No ccache.conf file found at ${CCACHE_DIR}/ccache.conf"
-  fi
   echo "::endgroup::"
 fi
 


### PR DESCRIPTION
From https://ccache.dev/manual/latest.html:

>-p, --show-config
Print current configuration options and from where they originate (environment variable, configuration file or compile-time default) in human-readable format.

>-z, --zero-stats
Zero the cache statistics (but not the configuration options).

<br>

Notes:
- Cache size message randomly printed above groups
- Packaging not printed in group (works in macOS though, docker.sh file issue?)