### PR TITLE
Ccache: Compiler check

### DIFF
--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -127,6 +127,12 @@ function ccachestatsverbose() {
   fi
 }
 
+if [[ $USE_CCACHE ]]; then
+  echo "::group::Show ccache config"
+  ccache --show-config
+  echo "::endgroup::"
+fi
+
 # Compile
 if [[ $USE_CCACHE ]]; then
   echo "::group::Show ccache stats"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -133,6 +133,7 @@ jobs:
       # Cache size over the entire repo is 10Gi:
       # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
       CCACHE_SIZE: 500M
+      CCACHE_COMPILERCHECK: content
       CMAKE_GENERATOR: 'Ninja'
 
     steps:
@@ -257,6 +258,7 @@ jobs:
     env:
       CCACHE_DIR: ${{github.workspace}}/.ccache/${{matrix.os}}-${{matrix.type}}
       CCACHE_SIZE: 500M
+      CCACHE_COMPILERCHECK: content
       DEVELOPER_DIR:
         /Applications/Xcode_${{matrix.xcode}}.app/Contents/Developer
       CMAKE_GENERATOR: 'Ninja'


### PR DESCRIPTION
https://ccache.dev/manual/latest.html

content > mtime

Picked up in macOS builds, but not Linux ones.
Probably due to docker.sh