### PR TITLE
CI: new aqtinstall action (Fix qt version in cache key)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -407,11 +407,18 @@ jobs:
           key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
           path: ${{ github.workspace }}/Qt
 
+      - name: Checkout action PR
+        uses: actions/checkout@v4
+        with:
+          repository: jurplel/install-qt-action
+          ref: refs/pull/335/head
+          path: action-src
+
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'
         # uses: jurplel/install-qt-action@4
         # uses: jurplel/install-qt-action@refs/pull/335/merge
-        #uses: pzhlkj6612/install-qt-action@fix/simpleSpec-ver-handling
+        # uses: pzhlkj6612/install-qt-action@fix/simpleSpec-ver-handling
         uses: jurplel/install-qt-action@7fddda425a96d23b453130d6171bd18f1ec7c082
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -273,7 +273,7 @@ jobs:
             make_package: 1
             override_target: 13
             package_suffix: "-macOS13_Intel"
-            qt_version: 6.11.0
+            qt_version: 6.11
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Intel
@@ -289,7 +289,7 @@ jobs:
             cmake_generator: Ninja
             make_package: 1
             package_suffix: "-macOS14"
-            qt_version: 6.11.0
+            qt_version: 6.11.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
@@ -305,7 +305,7 @@ jobs:
             cmake_generator: Ninja
             make_package: 1
             package_suffix: "-macOS15"
-            qt_version: 6.11.0
+            qt_version: 6.*
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple
@@ -319,7 +319,7 @@ jobs:
             
             ccache_eviction_age: 7d
             cmake_generator: Ninja
-            qt_version: 6.11.0
+            qt_version: 6
             qt_arch: clang_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             soc: Apple

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -376,37 +376,6 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
 
-      - name: "[macOS] Restore thin Qt ${{ matrix.qt_version }} libraries"
-        if: matrix.os == 'macOS'
-        id: restore_qt
-        uses: actions/cache/restore@v5
-        with:
-          key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
-          path: ${{ github.workspace }}/Qt
-
-      # Using jurplel/install-qt-action to install Qt without using brew
-      # Qt build using vcpkg either just fails or takes too long to build
-      - name: "[macOS] Install fat Qt ${{ matrix.qt_version }}"
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
-        uses: jurplel/install-qt-action@v4
-        with:
-          arch: ${{ matrix.qt_arch }}
-          cache: false
-          dir: ${{ github.workspace }}
-          modules: ${{ matrix.qt_modules }}
-          version: ${{ matrix.qt_version }}
-
-      - name: "[macOS] Create thin Qt libraries"
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
-        run: .ci/thin_macos_qtlib.sh
-
-      - name: "[macOS] Cache thin Qt libraries"
-        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
-          path: ${{ github.workspace }}/Qt
-
       - name: Checkout action PR
         uses: actions/checkout@v4
         with:
@@ -424,6 +393,38 @@ jobs:
       - run: |
           cd action
           npm run build
+
+      - name: "[macOS] Restore thin Qt ${{ matrix.qt_version }} libraries"
+        if: matrix.os == 'macOS'
+        id: restore_qt
+        uses: actions/cache/restore@v5
+        with:
+          key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
+          path: ${{ github.workspace }}/Qt
+
+      # Using jurplel/install-qt-action to install Qt without using brew
+      # Qt build using vcpkg either just fails or takes too long to build
+      - name: "[macOS] Install fat Qt ${{ matrix.qt_version }}"
+        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+        # uses: jurplel/install-qt-action@v4
+        uses: ./
+        with:
+          arch: ${{ matrix.qt_arch }}
+          cache: false
+          dir: ${{ github.workspace }}
+          modules: ${{ matrix.qt_modules }}
+          version: ${{ matrix.qt_version }}
+
+      - name: "[macOS] Create thin Qt libraries"
+        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+        run: .ci/thin_macos_qtlib.sh
+
+      - name: "[macOS] Cache thin Qt libraries"
+        if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
+          path: ${{ github.workspace }}/Qt
 
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.8.*
+            qt_version: 6.*.*
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
@@ -428,11 +428,6 @@ jobs:
 
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'
-        # uses: jurplel/install-qt-action@4
-        # uses: jurplel/install-qt-action@refs/pull/335/merge
-        # uses: pzhlkj6612/install-qt-action@fix/simpleSpec-ver-handling
-        # uses: jurplel/install-qt-action@7fddda425a96d23b453130d6171bd18f1ec7c082
-        # uses: ./action-src
         uses: ./
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6
+            qt_version: 6.12.*
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -412,7 +412,18 @@ jobs:
         with:
           repository: jurplel/install-qt-action
           ref: refs/pull/335/head
-          path: action-src
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: action/
+      - run: |
+          cd action
+          npm ci || npm install
+        shell: bash
+      - run: |
+          cd action
+          npm run build
 
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'
@@ -420,7 +431,8 @@ jobs:
         # uses: jurplel/install-qt-action@refs/pull/335/merge
         # uses: pzhlkj6612/install-qt-action@fix/simpleSpec-ver-handling
         # uses: jurplel/install-qt-action@7fddda425a96d23b453130d6171bd18f1ec7c082
-        uses: ./action-src
+        # uses: ./action-src
+        uses: ./
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
           aqtsource: git+https://github.com/miurahr/aqtinstall.git

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.*
+            qt_version: 6
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -376,8 +376,6 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
 
-
-
       - name: "[macOS] Restore thin Qt ${{ matrix.qt_version }} libraries"
         if: matrix.os == 'macOS'
         id: restore_qt
@@ -411,7 +409,7 @@ jobs:
 
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@refs/pull/335/merge
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
           aqtsource: git+https://github.com/miurahr/aqtinstall.git

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.10.*
+            qt_version: 6.8.*
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release
@@ -378,17 +378,17 @@ jobs:
 
 
 
-      - name: "[macOS] Restore thin Qt ${{ steps.resolve_qt_version.outputs.version }} libraries"
+      - name: "[macOS] Restore thin Qt ${{ matrix.qt_version }} libraries"
         if: matrix.os == 'macOS'
         id: restore_qt
         uses: actions/cache/restore@v5
         with:
-          key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
+          key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
           path: ${{ github.workspace }}/Qt
 
       # Using jurplel/install-qt-action to install Qt without using brew
       # Qt build using vcpkg either just fails or takes too long to build
-      - name: "[macOS] Install fat Qt ${{ steps.resolve_qt_version.outputs.version }}"
+      - name: "[macOS] Install fat Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
         uses: jurplel/install-qt-action@v4
         with:
@@ -396,7 +396,7 @@ jobs:
           cache: false
           dir: ${{ github.workspace }}
           modules: ${{ matrix.qt_modules }}
-          version: ${{ steps.resolve_qt_version.outputs.version }}
+          version: ${{ matrix.qt_version }}
 
       - name: "[macOS] Create thin Qt libraries"
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
@@ -406,7 +406,7 @@ jobs:
         if: matrix.os == 'macOS' && steps.restore_qt.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
-          key: thin-qt-macos-${{ matrix.soc }}-${{ steps.resolve_qt_version.outputs.version }}
+          key: thin-qt-macos-${{ matrix.soc }}-${{ matrix.qt_version }}
           path: ${{ github.workspace }}/Qt
 
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.11
+            qt_version: 6.*
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -376,7 +376,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
 
-      - name: "Install aqtinstall"
+      - name: "Install aqtinstall "
         run: pipx install aqtinstall
 
       # Resolve given wildcard versions (e.g. Qt 6.6.*) to latest version via aqtinstall to avoid stale caches on new releases

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.*.*
+            qt_version: 6.11
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -409,7 +409,10 @@ jobs:
 
       - name: "[Windows] Install Qt ${{ matrix.qt_version }}"
         if: matrix.os == 'Windows'
-        uses: jurplel/install-qt-action@refs/pull/335/merge
+        # uses: jurplel/install-qt-action@4
+        # uses: jurplel/install-qt-action@refs/pull/335/merge
+        #uses: pzhlkj6612/install-qt-action@fix/simpleSpec-ver-handling
+        uses: jurplel/install-qt-action@7fddda425a96d23b453130d6171bd18f1ec7c082
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
           aqtsource: git+https://github.com/miurahr/aqtinstall.git

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -376,14 +376,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           restore-keys: ccache-${{ matrix.runner }}-${{ matrix.soc }}-${{ matrix.type }}-
 
-      - name: "Install aqtinstall "
-        run: pipx install aqtinstall
 
-      # Resolve given wildcard versions (e.g. Qt 6.6.*) to latest version via aqtinstall to avoid stale caches on new releases
-      - name: "Resolve latest Qt patch version"
-        id: resolve_qt_version
-        shell: bash
-        run: .ci/resolve_latest_aqt_qt_version.sh "${{ matrix.qt_version }}"
 
       - name: "[macOS] Restore thin Qt ${{ steps.resolve_qt_version.outputs.version }} libraries"
         if: matrix.os == 'macOS'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -335,7 +335,7 @@ jobs:
             cmake_generator_platform: x64
             make_package: 1
             package_suffix: "-Win10"
-            qt_version: 6.11.0
+            qt_version: 6.10.*
             qt_arch: win64_msvc2022_64
             qt_modules: qtimageformats qtmultimedia qtwebsockets
             type: Release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -419,7 +419,8 @@ jobs:
         # uses: jurplel/install-qt-action@4
         # uses: jurplel/install-qt-action@refs/pull/335/merge
         # uses: pzhlkj6612/install-qt-action@fix/simpleSpec-ver-handling
-        uses: jurplel/install-qt-action@7fddda425a96d23b453130d6171bd18f1ec7c082
+        # uses: jurplel/install-qt-action@7fddda425a96d23b453130d6171bd18f1ec7c082
+        uses: ./action-src
         with:
           # Qt 6.11.0 only works with aqtinstall directly from git until aqtinstall 3.4 is released
           aqtsource: git+https://github.com/miurahr/aqtinstall.git

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -418,7 +418,7 @@ jobs:
           arch: ${{ matrix.qt_arch }}
           cache: true
           modules: ${{ matrix.qt_modules }}
-          version: ${{ steps.resolve_qt_version.outputs.version }}
+          version: ${{ matrix.qt_version }}
 
       - name: "[Windows] Install NSIS"
         if: matrix.os == 'Windows'


### PR DESCRIPTION
- As is with fixed `6.11.0` input and aqt wildcard resolution steps:
  <img width="1375" height="193" alt="image" src="https://github.com/user-attachments/assets/dfa35a32-2f7e-4be7-8ceb-7b2ddeea2d6c" />

- Dynamic `6.10.*` input and aqt wildcard resolution steps:
  <img width="1373" height="195" alt="image" src="https://github.com/user-attachments/assets/4f14a6f8-ae70-401e-9a06-fbf6a8581f84" />

- Dynamic `6.10.*` input without aqt wildcard resolution steps:
  <img width="1368" height="188" alt="image" src="https://github.com/user-attachments/assets/9ccb66ed-feeb-41f4-a916-2ff178f12218" />

<br>

- With **new install-qt-action** and dynamic `6.8.*` input **without aqt wildcard resolution** steps:
  <img width="1370" height="161" alt="image" src="https://github.com/user-attachments/assets/cf039e24-a298-4fc8-899b-4fbe4414814c" />

- With new install-qt-action and dynamic `6.*.*` input without aqt wildcard resolution steps:
  <img width="1370" height="190" alt="image" src="https://github.com/user-attachments/assets/722c2ffd-c16c-493e-8b1e-96d80bd111f0" />

- With new install-qt-action and `6.11` input without aqt wildcard resolution steps:
  <img width="1367" height="162" alt="image" src="https://github.com/user-attachments/assets/22348d8b-be67-4feb-8904-fb950a28f078" />

- With new install-qt-action and dynamic `6.*` input without aqt wildcard resolution steps:
  <img width="1370" height="190" alt="image" src="https://github.com/user-attachments/assets/77eb0bed-3a39-4f5b-9ac3-8affbb07ee2d" />

- With new install-qt-action and `6` input without aqt wildcard resolution steps:
  <img width="1372" height="191" alt="image" src="https://github.com/user-attachments/assets/e6fe8730-6491-4c03-babe-634e633e4bc6" />

  ```
  Resolving Qt version 6...
  C:\hostedtoolcache\windows\Python\3.14.5\x64\python.exe -m aqt list-qt windows desktop --spec 6 --latest-version
  6.12.0
  ```
  ```
  Automatic cache miss, will cache this run
  ```

- With new install-qt-action and `6.12.*` input without aqt wildcard resolution steps with active cache:
  <img width="1371" height="195" alt="image" src="https://github.com/user-attachments/assets/8a17da09-43bd-4897-bb53-0ae8adb68650" />

  ```
  Resolving Qt version 6.12.*...
  C:\hostedtoolcache\windows\Python\3.14.5\x64\python.exe -m aqt list-qt windows desktop --spec 6.12.* --latest-version
  6.12.0
  ```
  ```
  Cache hit for: install-qt-action-windows-10.0.26100-desktop-win64_msvc2022_64-6.12.0-D:\a\Cockatrice\Qt-==1.1.*-git+https://github.com/miurahr/aqtinstall.git-==3.3.*-qtimageformats-qtmultimedia-qtwebsockets
  Received 134217728 of 503211178 (26.7%), 117.3 MBs/sec
  Received 297795584 of 503211178 (59.2%), 135.4 MBs/sec
  Received 486539264 of 503211178 (96.7%), 149.7 MBs/sec
  Received 503211178 of 503211178 (100.0%), 145.6 MBs/sec
  Cache Size: ~480 MB (503211178 B)
  "C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/34bafc65-52ba-4eb7-850c-12b58c32cc28/cache.tzst -P -C D:/a/Cockatrice/Cockatrice --force-local --use-compress-program "zstd -d"
  Cache restored successfully
  Automatic cache hit with key "install-qt-action-windows-10.0.26100-desktop-win64_msvc2022_64-6.12.0-D:\a\Cockatrice\Qt-==1.1.*-git+https://github.com/miurahr/aqtinstall.git-==3.3.*-qtimageformats-qtmultimedia-qtwebsockets"
  ```